### PR TITLE
Completed Issue #11: Added Edit/Delete UI for Requests

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -50,6 +50,10 @@
             android:label="Create Job"
             android:parentActivityName=".ui.myjobs.MyJobsActivity"
             android:theme="@style/Theme.SFUerrands.NoActionBar"/>
+        <activity
+            android:name=".ui.myjobs.EditJobActivity"
+            android:parentActivityName=".ui.myjobs.MyJobsActivity"
+            android:theme="@style/Theme.SFUerrands.NoActionBar" />
     </application>
 
 </manifest>

--- a/app/src/main/java/com/example/sfuerrands/ui/home/JobAdapter.kt
+++ b/app/src/main/java/com/example/sfuerrands/ui/home/JobAdapter.kt
@@ -6,14 +6,14 @@ import android.view.ViewGroup
 import android.widget.TextView
 import androidx.recyclerview.widget.RecyclerView
 import android.content.Intent
-
-
 import com.example.sfuerrands.R
+import com.example.sfuerrands.ui.myjobs.EditJobActivity // Make sure this import is here
 
-// This adapter connects our list of jobs to the RecyclerView
 class JobAdapter(private var jobs: List<Job>) : RecyclerView.Adapter<JobAdapter.JobViewHolder>() {
 
-    // ViewHolder holds the views for each job item
+    // 1. ADD THIS VARIABLE: A custom click listener (nullable)
+    var onJobClickListener: ((Job) -> Unit)? = null
+
     class JobViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
         val titleTextView: TextView = itemView.findViewById(R.id.jobTitle)
         val descriptionTextView: TextView = itemView.findViewById(R.id.jobDescription)
@@ -21,37 +21,37 @@ class JobAdapter(private var jobs: List<Job>) : RecyclerView.Adapter<JobAdapter.
         val paymentTextView: TextView = itemView.findViewById(R.id.jobPayment)
     }
 
-    // Create a new ViewHolder when needed
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): JobViewHolder {
         val view = LayoutInflater.from(parent.context)
             .inflate(R.layout.item_job, parent, false)
         return JobViewHolder(view)
     }
 
-    // Puts the data into the ViewHolder
     override fun onBindViewHolder(holder: JobViewHolder, position: Int) {
-        val job = jobs[position]  // Get the job at this position
+        val job = jobs[position]
 
-        // Set the text for each TextView
         holder.titleTextView.text = job.title
         holder.descriptionTextView.text = job.description
         holder.locationTextView.text = job.location
         holder.paymentTextView.text = job.payment
 
-        // Make entire card clickable
+        // 2. UPDATE THE CLICK LISTENER
         holder.itemView.setOnClickListener {
-            // Create intent to open JobDetailActivity
-            val intent = Intent(holder.itemView.context, JobDetailActivity::class.java)
 
-            // init the intent
-            intent.putExtra("JOB_ID", job.id)
-            intent.putExtra("JOB_TITLE", job.title)
-            intent.putExtra("JOB_DESCRIPTION", job.description)
-            intent.putExtra("JOB_LOCATION", job.location)
-            intent.putExtra("JOB_PAYMENT", job.payment)
-
-            // Start the detail activity
-            holder.itemView.context.startActivity(intent)
+            // Check if a custom listener exists (e.g., for "Requests" tab)
+            if (onJobClickListener != null) {
+                // Execute the custom action
+                onJobClickListener?.invoke(job)
+            } else {
+                // DEFAULT BEHAVIOR (for "Home" tab): Open View Details
+                val intent = Intent(holder.itemView.context, JobDetailActivity::class.java)
+                intent.putExtra("JOB_ID", job.id)
+                intent.putExtra("JOB_TITLE", job.title)
+                intent.putExtra("JOB_DESCRIPTION", job.description)
+                intent.putExtra("JOB_LOCATION", job.location)
+                intent.putExtra("JOB_PAYMENT", job.payment)
+                holder.itemView.context.startActivity(intent)
+            }
         }
     }
 
@@ -59,6 +59,6 @@ class JobAdapter(private var jobs: List<Job>) : RecyclerView.Adapter<JobAdapter.
 
     fun submitList(newJobs: List<Job>) {
         jobs = newJobs
-        notifyDataSetChanged() // fine for MVP; later you can use DiffUtil
+        notifyDataSetChanged()
     }
 }

--- a/app/src/main/java/com/example/sfuerrands/ui/myjobs/EditJobActivity.kt
+++ b/app/src/main/java/com/example/sfuerrands/ui/myjobs/EditJobActivity.kt
@@ -1,0 +1,103 @@
+package com.example.sfuerrands.ui.myjobs
+
+import android.os.Bundle
+import android.view.View
+import android.widget.Toast
+import androidx.appcompat.app.AppCompatActivity
+import com.example.sfuerrands.databinding.ActivityEditJobBinding
+
+class EditJobActivity : AppCompatActivity() {
+
+    private lateinit var binding: ActivityEditJobBinding
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        binding = ActivityEditJobBinding.inflate(layoutInflater)
+        setContentView(binding.root)
+
+        // Set up the toolbar
+        setSupportActionBar(binding.toolbar)
+        supportActionBar?.setDisplayHomeAsUpEnabled(true)
+        supportActionBar?.title = "Edit Job"
+
+        // --- 1. PRE-FILL DATA ---
+        // Retrieve the data sent from RequestsFragment
+        val title = intent.getStringExtra("JOB_TITLE")
+        val description = intent.getStringExtra("JOB_DESCRIPTION")
+        val campus = intent.getStringExtra("JOB_LOCATION")
+        val price = intent.getStringExtra("JOB_PAYMENT")
+
+        // Set the text in the input fields
+        binding.titleEditText.setText(title)
+        binding.descriptionEditText.setText(description)
+        binding.campusEditText.setText(campus)
+
+        // Strip the '$' sign from the price string (e.g., "$5.00" -> "5.00")
+        // because the input type is numberDecimal
+        val cleanPrice = price?.replace("$", "")?.trim()
+        binding.priceEditText.setText(cleanPrice)
+        // ------------------------
+
+        // --- 2. MOCK DATA TOGGLE ---
+        // Change this boolean manually to test the two states required by the ticket:
+        // true  = READ ONLY (Claimed)
+        // false = EDITABLE  (Unclaimed)
+        val isClaimed = false
+        // ---------------------------
+
+        setupUI(isClaimed)
+    }
+
+    private fun setupUI(isClaimed: Boolean) {
+        // Setup Button Click Listeners
+        binding.saveButton.setOnClickListener {
+            Toast.makeText(this, "Changes Saved (UI Only)", Toast.LENGTH_SHORT).show()
+            finish()
+        }
+
+        binding.deleteButton.setOnClickListener {
+            Toast.makeText(this, "Job Deleted (UI Only)", Toast.LENGTH_SHORT).show()
+            finish()
+        }
+
+        binding.backButton.setOnClickListener {
+            finish()
+        }
+
+        // Handle "Claimed" vs "Unclaimed" State
+        if (isClaimed) {
+            // STATE: CLAIMED (Read-Only)
+
+            binding.titleEditText.isEnabled = false
+            binding.descriptionEditText.isEnabled = false
+            binding.campusEditText.isEnabled = false
+            binding.priceEditText.isEnabled = false
+
+            binding.warningTextView.visibility = View.VISIBLE
+            binding.warningTextView.text = "This errand has been claimed and can no longer be edited."
+
+            binding.saveButton.visibility = View.GONE
+            binding.deleteButton.visibility = View.GONE
+            binding.backButton.visibility = View.VISIBLE
+
+        } else {
+            // STATE: UNCLAIMED (Editable)
+
+            binding.titleEditText.isEnabled = true
+            binding.descriptionEditText.isEnabled = true
+            binding.campusEditText.isEnabled = true
+            binding.priceEditText.isEnabled = true
+
+            binding.warningTextView.visibility = View.GONE
+
+            binding.saveButton.visibility = View.VISIBLE
+            binding.deleteButton.visibility = View.VISIBLE
+            binding.backButton.visibility = View.VISIBLE
+        }
+    }
+
+    override fun onSupportNavigateUp(): Boolean {
+        finish()
+        return true
+    }
+}

--- a/app/src/main/java/com/example/sfuerrands/ui/myjobs/RequestsFragment.kt
+++ b/app/src/main/java/com/example/sfuerrands/ui/myjobs/RequestsFragment.kt
@@ -60,6 +60,20 @@ class RequestsFragment : Fragment() {
 
         val adapter = JobAdapter(myPostedJobs)
 
+        // --- NEW LOGIC: Override the click to open "Edit Job" instead of "View Job" ---
+        adapter.onJobClickListener = { job ->
+            val intent = Intent(requireContext(), EditJobActivity::class.java)
+
+            // Pass the existing data to the edit screen so we can pre-fill the text boxes
+            intent.putExtra("JOB_TITLE", job.title)
+            intent.putExtra("JOB_DESCRIPTION", job.description)
+            intent.putExtra("JOB_LOCATION", job.location)
+            intent.putExtra("JOB_PAYMENT", job.payment) // Make sure to parse the '$' out later if needed
+
+            startActivity(intent)
+        }
+        // ---------------------------------------------------------------------------
+
         binding.requestsRecyclerView.apply {
             layoutManager = LinearLayoutManager(context)
             this.adapter = adapter

--- a/app/src/main/res/layout/activity_edit_job.xml
+++ b/app/src/main/res/layout/activity_edit_job.xml
@@ -1,0 +1,144 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <com.google.android.material.appbar.AppBarLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar">
+
+        <androidx.appcompat.widget.Toolbar
+            android:id="@+id/toolbar"
+            android:layout_width="match_parent"
+            android:layout_height="?attr/actionBarSize"
+            android:background="?attr/colorPrimary"
+            app:popupTheme="@style/ThemeOverlay.AppCompat.Light" />
+
+    </com.google.android.material.appbar.AppBarLayout>
+
+    <androidx.core.widget.NestedScrollView
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:fillViewport="true"
+        app:layout_behavior="@string/appbar_scrolling_view_behavior">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:padding="16dp">
+
+            <TextView
+                android:id="@+id/warningTextView"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="This errand has been claimed and can no longer be edited."
+                android:textColor="#D32F2F"
+                android:textStyle="bold"
+                android:gravity="center"
+                android:visibility="gone"
+                android:layout_marginBottom="16dp"/>
+
+            <com.google.android.material.textfield.TextInputLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="16dp"
+                android:hint="Title"
+                app:boxBackgroundMode="outline">
+
+                <com.google.android.material.textfield.TextInputEditText
+                    android:id="@+id/titleEditText"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:inputType="text"
+                    android:maxLines="1" />
+
+            </com.google.android.material.textfield.TextInputLayout>
+
+            <com.google.android.material.textfield.TextInputLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="16dp"
+                android:hint="Description"
+                app:boxBackgroundMode="outline">
+
+                <com.google.android.material.textfield.TextInputEditText
+                    android:id="@+id/descriptionEditText"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:gravity="top|start"
+                    android:inputType="textMultiLine"
+                    android:lines="4"
+                    android:maxLines="6"
+                    android:minLines="4" />
+
+            </com.google.android.material.textfield.TextInputLayout>
+
+            <com.google.android.material.textfield.TextInputLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="16dp"
+                android:hint="Campus"
+                app:boxBackgroundMode="outline">
+
+                <com.google.android.material.textfield.TextInputEditText
+                    android:id="@+id/campusEditText"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:inputType="text"
+                    android:maxLines="1" />
+
+            </com.google.android.material.textfield.TextInputLayout>
+
+            <com.google.android.material.textfield.TextInputLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="24dp"
+                android:hint="Price Offered"
+                app:boxBackgroundMode="outline"
+                app:prefixText="$">
+
+                <com.google.android.material.textfield.TextInputEditText
+                    android:id="@+id/priceEditText"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:inputType="numberDecimal"
+                    android:maxLines="1" />
+
+            </com.google.android.material.textfield.TextInputLayout>
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/saveButton"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:padding="12dp"
+                android:text="Save Changes"
+                android:textSize="16sp"
+                android:layout_marginBottom="8dp"/>
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/deleteButton"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:padding="12dp"
+                android:text="Delete Job"
+                android:textSize="16sp"
+                app:backgroundTint="#D32F2F"
+                android:layout_marginBottom="8dp"/>
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/backButton"
+                style="@style/Widget.MaterialComponents.Button.OutlinedButton"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:padding="12dp"
+                android:text="Back"
+                android:textSize="16sp" />
+
+        </LinearLayout>
+
+    </androidx.core.widget.NestedScrollView>
+
+</androidx.coordinatorlayout.widget.CoordinatorLayout>


### PR DESCRIPTION
<img width="302" height="627" alt="Screenshot 2025-11-21 at 9 34 16 PM" src="https://github.com/user-attachments/assets/a352a892-c6ef-4748-99b3-8b68a58f31b1" />

# Implement Edit/Delete Errand UI (Issue #11)

## Description
This PR implements the UI-only logic for editing and deleting errands from the "Requests" tab. It creates a new Edit screen that supports two states: **Editable** (for open jobs) and **Read-Only** (for claimed jobs).

## Changes by File

### 1. `AndroidManifest.xml`
- Registered the new `EditJobActivity`.
- Applied `Theme.SFUerrands.NoActionBar` to this activity to prevent the "IllegalStateException" crash (resolving the conflict between the system Action Bar and our custom Toolbar).
- Added `parentActivityName` to enable native Back arrow navigation.

### 2. `ui/myjobs/EditJobActivity.kt` (New File)
- Created the logic for the Edit Errand screen.
- **Pre-fill Logic:** Retrieves data passed via Intent (Title, Description, Price, Campus) and populates the text fields so the user sees existing data.
- **Mock Logic:** Implemented a boolean toggle (`isClaimed`) to simulate "Claimed" vs "Unclaimed" states.
  - *If Claimed:* Disables inputs, hides action buttons, shows "Back" button, and displays a red warning message.
  - *If Unclaimed:* Enables inputs and shows "Save" and "Delete" buttons.
- **Button Listeners:** Added Toast messages for Save/Delete actions (UI-only for now).

### 3. `res/layout/activity_edit_job.xml` (New File)
- Created the layout based on the "Create Job" design to ensure consistency.
- Added **"Save Changes"** (Primary) and **"Delete Job"** (Red/Danger) buttons.
- Added a **"Back"** button (Outlined) for the Read-Only state.
- Added a hidden **Warning TextView** that appears only when the job is claimed.

### 4. `ui/home/JobAdapter.kt`
- Refactored the adapter to support custom click actions.
- Added an optional `onJobClickListener` callback.
- **Logic Change:** If a listener is provided (Requests Tab), it executes the custom action (Edit). If null (Home Tab), it defaults to the original "View Details" behavior. This prevents breaking the Home feed.

### 5. `ui/myjobs/RequestsFragment.kt`
- Updated `setupRecyclerView` to define the custom click behavior.
- Intercepts clicks on the "Requests" list and launches `EditJobActivity` instead of `JobDetailActivity`.
- Passes the job details as Intent Extras to pre-fill the edit screen.

## How to Test
1. Go to **My Jobs** -> **Requests**.
2. Click on any job in the list.
3. **Verify:** The Edit screen opens with the job details already filled in.
4. **Verify:** You can click "Save" or "Delete" (shows a Toast message).
5. **Verify Rotation:** Rotate the screen; text inputs should persist.
6. *(Optional)* In `EditJobActivity.kt`, set `val isClaimed = true` to verify the Read-Only state (Red warning text, inputs disabled).