### PR TITLE
feat: implement job claiming logic and home screen filtering

### DIFF
--- a/app/src/main/java/com/example/sfuerrands/data/repository/ErrandRepository.kt
+++ b/app/src/main/java/com/example/sfuerrands/data/repository/ErrandRepository.kt
@@ -36,12 +36,6 @@ class ErrandRepository {
         query.runnerId?.let { q = q.whereEqualTo("runnerId", it) }
 
         // Ordering
-//        q = if (query.orderByCreatedAtDesc) {
-//            q.orderBy("createdAt", Query.Direction.DESCENDING)
-//        } else {
-//            q.orderBy("createdAt", Query.Direction.ASCENDING)
-//        }
-
         if (query.orderByCreatedAtDesc) q = q.orderBy("createdAt", Query.Direction.DESCENDING)
         if (query.orderByCreatedAtAsc) q = q.orderBy("createdAt", Query.Direction.ASCENDING)
 
@@ -133,7 +127,8 @@ class ErrandRepository {
             id,
             mapOf(
                 "runnerId" to runnerRef,
-                "status" to "claimed"
+                "status" to "claimed",
+                "claimedAt" to Timestamp.now()
             )
         )
     }

--- a/app/src/main/java/com/example/sfuerrands/ui/home/HomeFragment.kt
+++ b/app/src/main/java/com/example/sfuerrands/ui/home/HomeFragment.kt
@@ -12,7 +12,9 @@ import com.example.sfuerrands.data.repository.ErrandRepository
 import com.example.sfuerrands.databinding.FragmentHomeBinding
 import com.google.firebase.firestore.firestore
 import com.google.firebase.Firebase
+import com.google.firebase.auth.auth
 import com.google.firebase.firestore.ListenerRegistration
+
 class HomeFragment : Fragment() {
     private var _binding: FragmentHomeBinding? = null
     private val binding get() = _binding!!
@@ -52,6 +54,9 @@ class HomeFragment : Fragment() {
     }
 
     private fun listenForErrands() {
+        // 1. Get current User ID to filter out own posts
+        val currentUserId = Firebase.auth.currentUser?.uid
+
         val query = ErrandQuery(
             status = "open",
             orderByCreatedAtDesc = true,
@@ -61,7 +66,13 @@ class HomeFragment : Fragment() {
             query = query,
             onSuccess = { errands ->
                 Log.d("HomeFragment", "Got ${errands.size} errands")
-                val jobs = errands.map { e ->
+
+                // 2. Filter the list: Exclude errands where requesterId is me
+                val filteredErrands = errands.filter { errand ->
+                    errand.requesterId?.id != currentUserId
+                }
+
+                val jobs = filteredErrands.map { e ->
                     Job(
                         id = e.id,
                         title = e.title,


### PR DESCRIPTION
# Feature: Job Claiming Logic & Home Screen Filtering

## 📝 Description
This PR completes the "Home Page" and "Job Detail" functionality by implementing the logic for a user to claim an errand and ensuring users do not see their own job requests in the main feed.

## 🚀 Changes Implemented

### 1. Home Screen Filtering
- **Logic:** Updated `HomeFragment` to filter the list of fetched errands.
- **Behavior:** The "Available Jobs" feed now excludes any errand where the `requesterId` matches the current logged-in user's UID.

### 2. Job Claiming Logic
- **UI:** Connected the "Accept" button in `JobDetailActivity`.
- **Database:** Updated `ErrandRepository` to set the `claimedAt` timestamp and change the status to `claimed` when a runner accepts a job.
- **Validation:** Added checks to ensure a user is logged in and the job ID is valid before processing the claim.

### 3. Repository Updates
- Added `claimedAt: Timestamp.now()` to the `claimErrand` function map to track when jobs are accepted.

## 📂 Files Modified
* `app/src/main/java/com/example/sfuerrands/data/repository/ErrandRepository.kt`
* `app/src/main/java/com/example/sfuerrands/ui/home/HomeFragment.kt`
* `app/src/main/java/com/example/sfuerrands/ui/home/JobDetailActivity.kt`