### PR TITLE
feat(ui): enable full-screen photo viewer in Task Details

### DIFF
--- a/app/src/main/java/com/example/sfuerrands/ui/myjobs/TaskDetailActivity.kt
+++ b/app/src/main/java/com/example/sfuerrands/ui/myjobs/TaskDetailActivity.kt
@@ -10,6 +10,7 @@ import androidx.recyclerview.widget.GridLayoutManager
 import com.example.sfuerrands.data.repository.ErrandRepository
 import com.example.sfuerrands.databinding.ActivityTaskDetailBinding
 import com.example.sfuerrands.ui.home.MediaAdapter
+import com.example.sfuerrands.ui.preview.ImagePreviewNavigator // Added import
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.storage.FirebaseStorage
 import kotlinx.coroutines.launch
@@ -111,8 +112,13 @@ class TaskDetailActivity : AppCompatActivity() {
     }
 
     private fun setupPhotoDisplay() {
-        mediaAdapter = MediaAdapter(downloadUrls) { position, photoUrl ->
-            Toast.makeText(this, "Photo ${position + 1}", Toast.LENGTH_SHORT).show()
+        // Updated to use ImagePreviewNavigator instead of Toast
+        mediaAdapter = MediaAdapter(downloadUrls) { position, _ ->
+            ImagePreviewNavigator.open(
+                context = this@TaskDetailActivity,
+                urls = downloadUrls,
+                startIndex = position
+            )
         }
 
         binding.photosRecyclerView.apply {


### PR DESCRIPTION
# Enable Full-Screen Photo Viewer in Task Details

## Description
This PR updates the `TaskDetailActivity` to allow users to view task photos in full-screen mode. Previously, tapping a photo in the Task Details screen only displayed a "Photo [n]" Toast message. 

Now, tapping a photo opens the `ImagePreviewActivity` (via `ImagePreviewNavigator`), matching the behavior already present in the Home/Job Details screen. This allows runners to properly inspect photos associated with a task.

## Changes
- **Modified `TaskDetailActivity.kt`**:
  - Imported `ImagePreviewNavigator`.
  - Updated the `MediaAdapter` click listener in `setupPhotoDisplay()` to call `ImagePreviewNavigator.open()` instead of showing a `Toast`.

## Related Issue
Fixes #33

<img width="271" height="552" alt="Screenshot 2025-11-28 at 5 30 39 PM" src="https://github.com/user-attachments/assets/4ee4e1b2-3ce1-4ea1-93d8-00cbb3de9dfc" />
