### PR TITLE
feat: Implement Offer System for errands (#41)

### DIFF
--- a/app/src/main/java/com/example/sfuerrands/data/models/Errand.kt
+++ b/app/src/main/java/com/example/sfuerrands/data/models/Errand.kt
@@ -19,5 +19,8 @@ data class Errand (
     val createdAt: Timestamp? = null,
     val claimedAt: Timestamp? = null,
     val expectedCompletionAt: Timestamp? = null,
-    val photoUrls: List<String> = emptyList()      // Array of photo URLs
+    val photoUrls: List<String> = emptyList(),      // Array of photo URLs
+
+    // [NEW] List to store references to users who have offered to help
+    val offers: List<DocumentReference> = emptyList()
 )

--- a/app/src/main/java/com/example/sfuerrands/data/repository/ErrandRepository.kt
+++ b/app/src/main/java/com/example/sfuerrands/data/repository/ErrandRepository.kt
@@ -8,6 +8,7 @@ import com.google.firebase.firestore.ListenerRegistration
 import com.google.firebase.firestore.Query
 import com.google.firebase.firestore.firestore
 import com.google.firebase.Firebase
+import com.google.firebase.firestore.FieldValue
 import kotlinx.coroutines.tasks.await
 
 class ErrandRepository {
@@ -131,6 +132,19 @@ class ErrandRepository {
                 "claimedAt" to Timestamp.now()
             )
         )
+    }
+
+    /**
+     * Adds the current user (runner) to the offers list of an errand.
+     * Uses arrayUnion to ensure no duplicates are added.
+     */
+    suspend fun sendOffer(errandId: String, runnerUid: String) {
+        val runnerRef = db.collection("users").document(runnerUid)
+
+        // Atomically add the runner's reference to the 'offers' array
+        errandsCollection.document(errandId)
+            .update("offers", FieldValue.arrayUnion(runnerRef))
+            .await()
     }
 
 }

--- a/app/src/main/java/com/example/sfuerrands/ui/home/Job.kt
+++ b/app/src/main/java/com/example/sfuerrands/ui/home/Job.kt
@@ -12,5 +12,8 @@ data class Job(
     val isClaimed: Boolean = false,
     val requester: DocumentReference? = null,
     val runner: DocumentReference? = null,
-    val unreadMessageCount: Int = 0  // NEW: Track unread messages
+    val unreadMessageCount: Int = 0,
+
+    // [NEW] List of offers for the UI to display in the dropdown
+    val offers: List<DocumentReference> = emptyList()
 )

--- a/app/src/main/java/com/example/sfuerrands/ui/home/JobDetailActivity.kt
+++ b/app/src/main/java/com/example/sfuerrands/ui/home/JobDetailActivity.kt
@@ -52,13 +52,13 @@ class JobDetailActivity : AppCompatActivity() {
             finish()
         }
 
-        // Set up accept button
-        binding.acceptButton.setOnClickListener {
+        // Set up offer button (Updated for Offer System #41)
+        binding.offerButton.setOnClickListener {
             val currentUser = Firebase.auth.currentUser
 
             // 1. Check if user is logged in
             if (currentUser == null) {
-                Toast.makeText(this, "You must be logged in to accept jobs", Toast.LENGTH_SHORT).show()
+                Toast.makeText(this, "You must be logged in to offer help", Toast.LENGTH_SHORT).show()
                 return@setOnClickListener
             }
 
@@ -69,26 +69,26 @@ class JobDetailActivity : AppCompatActivity() {
             }
 
             // 3. Disable button to prevent double-clicks
-            binding.acceptButton.isEnabled = false
-            binding.acceptButton.text = "Claiming..."
+            binding.offerButton.isEnabled = false
+            binding.offerButton.text = "Sending Offer..."
 
-            // 4. Perform the claim operation
+            // 4. Perform the offer operation
             lifecycleScope.launch {
                 try {
-                    // Update Firestore via Repository
-                    errandRepository.claimErrand(jobId, currentUser.uid)
+                    // Send offer via Repository instead of claiming directly
+                    errandRepository.sendOffer(jobId, currentUser.uid)
 
-                    Toast.makeText(this@JobDetailActivity, "Job Accepted!", Toast.LENGTH_SHORT).show()
+                    Toast.makeText(this@JobDetailActivity, "Offer Sent!", Toast.LENGTH_SHORT).show()
 
                     // Close activity. The Home list will refresh automatically via the listener.
                     finish()
                 } catch (e: Exception) {
                     // Handle failure
-                    Toast.makeText(this@JobDetailActivity, "Failed to claim: ${e.message}", Toast.LENGTH_LONG).show()
+                    Toast.makeText(this@JobDetailActivity, "Failed to send offer: ${e.message}", Toast.LENGTH_LONG).show()
 
                     // Re-enable button on failure
-                    binding.acceptButton.isEnabled = true
-                    binding.acceptButton.text = "Accept"
+                    binding.offerButton.isEnabled = true
+                    binding.offerButton.text = "Offer Help"
                 }
             }
         }

--- a/app/src/main/res/layout/activity_job_detail.xml
+++ b/app/src/main/res/layout/activity_job_detail.xml
@@ -15,7 +15,6 @@
             android:layout_height="wrap_content"
             android:padding="16dp">
 
-            <!-- Icon -->
             <ImageView
                 android:id="@+id/detailJobIcon"
                 android:layout_width="72dp"
@@ -26,7 +25,6 @@
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintTop_toTopOf="parent" />
 
-            <!-- Title -->
             <TextView
                 android:id="@+id/detailJobTitle"
                 android:layout_width="0dp"
@@ -41,7 +39,6 @@
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintEnd_toEndOf="parent" />
 
-            <!-- Media gallery (HORIZONTAL) -->
             <androidx.recyclerview.widget.RecyclerView
                 android:id="@+id/mediaRecycler"
                 android:layout_width="0dp"
@@ -54,7 +51,6 @@
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintEnd_toEndOf="parent" />
 
-            <!-- Description BELOW the gallery -->
             <TextView
                 android:id="@+id/detailJobDescription"
                 android:layout_width="0dp"
@@ -69,7 +65,6 @@
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintEnd_toEndOf="parent" />
 
-            <!-- Location row -->
             <TextView
                 android:id="@+id/locationLabel"
                 android:layout_width="wrap_content"
@@ -93,7 +88,6 @@
                 app:layout_constraintBottom_toBottomOf="@id/locationLabel"
                 app:layout_constraintEnd_toEndOf="parent" />
 
-            <!-- Payment row -->
             <TextView
                 android:id="@+id/paymentLabel"
                 android:layout_width="wrap_content"
@@ -119,7 +113,6 @@
                 app:layout_constraintBottom_toBottomOf="@id/paymentLabel"
                 app:layout_constraintEnd_toEndOf="parent" />
 
-            <!-- Buttons -->
             <LinearLayout
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
@@ -142,13 +135,13 @@
                     android:textColor="@android:color/white" />
 
                 <Button
-                    android:id="@+id/acceptButton"
+                    android:id="@+id/offerButton"
                     android:layout_width="0dp"
                     android:layout_height="wrap_content"
                     android:layout_marginStart="8dp"
                     android:layout_weight="1"
                     android:backgroundTint="#4CAF50"
-                    android:text="Accept"
+                    android:text="Offer Help"
                     android:textColor="@android:color/white" />
             </LinearLayout>
 

--- a/app/src/main/res/layout/item_job.xml
+++ b/app/src/main/res/layout/item_job.xml
@@ -14,14 +14,12 @@
         android:clipChildren="false"
         android:padding="16dp">
 
-        <!-- Top Row: Title + Claimed Badge -->
         <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:orientation="horizontal"
             android:gravity="center_vertical">
 
-            <!-- Job Title -->
             <TextView
                 android:id="@+id/jobTitle"
                 android:layout_width="0dp"
@@ -32,7 +30,6 @@
                 android:textStyle="bold"
                 android:textColor="@android:color/black" />
 
-            <!-- Claimed Badge -->
             <TextView
                 android:id="@+id/claimedBadge"
                 android:layout_width="wrap_content"
@@ -50,7 +47,6 @@
 
         </LinearLayout>
 
-        <!-- Job Description -->
         <TextView
             android:id="@+id/jobDescription"
             android:layout_width="match_parent"
@@ -135,6 +131,34 @@
                 android:textSize="14sp"
                 android:textStyle="bold"
                 android:textColor="#4CAF50" />
+
+        </LinearLayout>
+
+        <LinearLayout
+            android:id="@+id/offerSelectionLayout"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="12dp"
+            android:orientation="horizontal"
+            android:gravity="center_vertical"
+            android:visibility="gone">
+
+            <Spinner
+                android:id="@+id/offerSpinner"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:layout_marginEnd="8dp"
+                android:minHeight="48dp"
+                android:spinnerMode="dropdown" />
+
+            <Button
+                android:id="@+id/acceptOfferButton"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="Accept"
+                android:textSize="12sp"
+                style="@style/Widget.MaterialComponents.Button" />
 
         </LinearLayout>
 


### PR DESCRIPTION
# Offer System Implementation #41

## Description
This PR implements the new "Offer" workflow, replacing the immediate "Claim" system. Runners can now offer to help with an errand, and Requesters (job owners) can review a list of potential runners and select one to accept.

## Changes

### 🏗️ Backend & Data Model
* **Updated `Errand.kt`**: Added an `offers` list property (`List<DocumentReference>`) to track users who have offered help.
* **Updated `ErrandRepository.kt`**: Added `sendOffer(errandId, runnerUid)` function to atomically append a runner's reference to the `offers` array in Firestore using `FieldValue.arrayUnion`.

### 🏃 Runner UI (Home Screen)
* **`activity_job_detail.xml`**: Renamed the primary action button to `offerButton` and changed text to "Offer Help".
* **`JobDetailActivity.kt`**: Updated logic to call `errandRepository.sendOffer()` instead of immediately claiming the job. Added UI feedback ("Offer Sent!").

### 👤 Requester UI (My Jobs Screen)
* **`Job.kt`**: Added `offers` field to the UI model to pass data to the adapter.
* **`item_job.xml`**: Added a hidden `LinearLayout` containing a `Spinner` (dropdown) and an "Accept" `Button` for managing offers.
* **`JobAdapter.kt`**:
    * Added logic to fetch runner details (Name & Rating) asynchronously for the dropdown.
    * Implemented `isRequesterMode` flag to ensure offer controls only appear on the Requests screen.
    * Added logic to handle the "Accept" click event.
* **`RequestsFragment.kt`**:
    * Enabled `isRequesterMode` for the adapter.
    * Implemented the acceptance logic to assign the selected runner to the errand.

### 🐛 Fixes
* **Race Condition Fix**: Updated `JobAdapter` to keep the "Accept" button hidden until runner data is fully loaded to prevent unresponsive UI clicks.
* **Lifecycle Safety**: Updated `JobAdapter` constructor to accept a `LifecycleOwner`, ensuring asynchronous data loading (coroutines) operates within the correct scope.

<img width="276" height="582" alt="Screenshot 2025-11-30 at 2 43 11 PM" src="https://github.com/user-attachments/assets/969fa0f8-7445-487d-9342-44b6e74b0eb2" />

